### PR TITLE
Use correct user name for bot 2

### DIFF
--- a/server/botany/templates/botany/_bot_games.html
+++ b/server/botany/templates/botany/_bot_games.html
@@ -5,7 +5,7 @@
       {% if bot == g.bot1 %}
       As bot1 against {{ g.bot2.user_name }} : : {{ g.bot2.name }}
       {% else %}
-      As bot2 against {{ g.bot2.user_name }} : : {{ g.bot1.name }}
+      As bot2 against {{ g.bot1.user_name }} : : {{ g.bot1.name }}
       {% endif %}
       ({{ g.summary }})
     </a>


### PR DESCRIPTION
When played as bot 2, show the username owning bot 1. This fixes issue #4