### PR TITLE
client: Report server errors if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ db.sqlite3
 dist
 htmlcov
 tmp
+__pycache__

--- a/client/src/botany_client/client.py
+++ b/client/src/botany_client/client.py
@@ -34,7 +34,10 @@ def init(origin):
     setup_url = origin + "/api/setup/"
     rsp = requests.get(setup_url)
     if not rsp.ok:
-        raise click.UsageError(f"Received {rsp.status_code} from server")
+        msg = f"Received {rsp.status_code} from server"
+        if rsp.text:
+            msg = f"{msg}: {rsp.text}"
+        raise click.UsageError(msg)
 
     settings = rsp.json()
 
@@ -75,7 +78,10 @@ def submit(path):
     if rsp.status_code == 404:
         raise click.UsageError("Could not find user with API token")
     elif not rsp.ok:
-        raise click.UsageError(f"Received {rsp.status_code} from server")
+        msg = f"Received {rsp.status_code} from server"
+        if rsp.text:
+            msg = f"{msg}: {rsp.text}"
+        raise click.UsageError(msg)
 
     print("Bot code submitted successfully!")
 


### PR DESCRIPTION
This means you get

```
Usage: botany submit [OPTIONS] PATH

Error: Received 400 from server: Tournament has closed
```

when a tournament has closed, rather than just `Error: Received 400 from server`