### PR TITLE
Return status 401 when API authentication fails

### DIFF
--- a/client/src/botany_client/client.py
+++ b/client/src/botany_client/client.py
@@ -74,11 +74,12 @@ def submit(path):
     bot_name = os.path.basename(path)
     utils.read_and_validate_bot_code(path)
 
-    data = {"api_token": utils.get_setting("api_token"), "bot_name": bot_name}
+    data = {"bot_name": bot_name}
+    headers = {"Authorization": utils.get_setting("api_token")}
 
     with open(path) as bot_file:
         files = {"bot_code": bot_file}
-        rsp = requests.post(submit_url, data=data, files=files)
+        rsp = requests.post(submit_url, data=data, headers=headers, files=files)
 
     if rsp.status_code == 404:
         raise click.UsageError("Could not find user with API token")

--- a/client/src/botany_client/client.py
+++ b/client/src/botany_client/client.py
@@ -81,7 +81,7 @@ def submit(path):
         files = {"bot_code": bot_file}
         rsp = requests.post(submit_url, data=data, headers=headers, files=files)
 
-    if rsp.status_code == 404:
+    if rsp.status_code == 401:
         raise click.UsageError("Could not find user with API token")
     elif not rsp.ok:
         msg = f"Received {rsp.status_code} from server"
@@ -123,7 +123,7 @@ def download(path):
 
     rsp = requests.get(download_url, headers=headers)
 
-    if rsp.status_code == 404:
+    if rsp.status_code == 401:
         raise click.UsageError("Could not find user with API token")
     elif not rsp.ok:
         msg = f"Received {rsp.status_code} from server"

--- a/server/botany/tests/test_views.py
+++ b/server/botany/tests/test_views.py
@@ -12,6 +12,10 @@ from botany import views
 from botany.tests import factories
 
 
+YESTERDAY = datetime.now(timezone.utc) - timedelta(days=1)
+TOMORROW = datetime.now(timezone.utc) + timedelta(days=1)
+
+
 class DownloadBotsCodeBaseTestCase(TestCase):
     # Base test case for all download views
 
@@ -33,9 +37,7 @@ class DownloadBotsCodeBaseTestCase(TestCase):
         factories.create_bot(brad, **(self.test_data[1]))
 
 
-@override_settings(
-    BOTANY_TOURNAMENT_CLOSE_AT=datetime.now(timezone.utc) - timedelta(days=1)
-)
+@override_settings(BOTANY_TOURNAMENT_CLOSE_AT=YESTERDAY)
 class DownloadBotsCodeHelperFunctionTest(DownloadBotsCodeBaseTestCase):
 
     def test_download_bots_code_helper_function(self):
@@ -61,9 +63,7 @@ class DownloadBotsCodeHelperFunctionTest(DownloadBotsCodeBaseTestCase):
                     )
 
 
-@override_settings(
-    BOTANY_TOURNAMENT_CLOSE_AT=datetime.now(timezone.utc) - timedelta(days=1)
-)
+@override_settings(BOTANY_TOURNAMENT_CLOSE_AT=YESTERDAY)
 class DownloadBotsCodeViewTest(DownloadBotsCodeBaseTestCase):
 
     def test_download_bots_code_view(self):
@@ -88,10 +88,7 @@ class DownloadBotsCodeViewTest(DownloadBotsCodeBaseTestCase):
         with self.assertRaises(PermissionDenied):
             views.download_bots_code(request)
 
-    @override_settings(
-        BOTANY_TOURNAMENT_CLOSE_AT=datetime.now(
-            timezone.utc) + timedelta(days=1)
-    )
+    @override_settings(BOTANY_TOURNAMENT_CLOSE_AT=TOMORROW)
     def test_cannot_download_bots_code_before_tournament_ends(self):
         request = self.factory.get("")
         request.user = self.user
@@ -100,9 +97,7 @@ class DownloadBotsCodeViewTest(DownloadBotsCodeBaseTestCase):
             views.download_bots_code(request)
 
 
-@override_settings(
-    BOTANY_TOURNAMENT_CLOSE_AT=datetime.now(timezone.utc) - timedelta(days=1)
-)
+@override_settings(BOTANY_TOURNAMENT_CLOSE_AT=YESTERDAY)
 class APIDownloadBotsCodeViewTest(DownloadBotsCodeBaseTestCase):
 
     def setUp(self):
@@ -125,10 +120,7 @@ class APIDownloadBotsCodeViewTest(DownloadBotsCodeBaseTestCase):
             "Return value of _download_bots_code"
         )
 
-    @override_settings(
-        BOTANY_TOURNAMENT_CLOSE_AT=datetime.now(
-            timezone.utc) + timedelta(days=1)
-    )
+    @override_settings(BOTANY_TOURNAMENT_CLOSE_AT=TOMORROW)
     def test_cannot_download_bots_code_via_api_before_tournament_ends(self):
         request = self.factory.get("")
         request.META["HTTP_AUTHORIZATION"] = "TOKEN"

--- a/server/botany/tests/test_views.py
+++ b/server/botany/tests/test_views.py
@@ -138,5 +138,5 @@ class APIDownloadBotsCodeViewTest(DownloadBotsCodeBaseTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.content.decode("utf-8"),
-            "Unable to download bots while tournament is still in progress"
+            "Unable to download bots until tournament is complete"
         )

--- a/server/botany/tests/test_views.py
+++ b/server/botany/tests/test_views.py
@@ -37,6 +37,16 @@ class APISubmitViewTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_request_with_no_token_receives_401(self):
+        request = self.factory.post("", data={})
+
+        response = views.api_submit(request)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.content.decode("utf-8"), "API token not provided or empty"
+        )
+
     def test_request_with_invalid_token_receives_401(self):
         request = self.factory.post("")
         request.META["HTTP_AUTHORIZATION"] = "WRONG-TOKEN"
@@ -45,8 +55,7 @@ class APISubmitViewTest(TestCase):
 
         self.assertEqual(response.status_code, 401)
         self.assertEqual(
-            response.content.decode("utf-8"),
-            "Invalid API token"
+            response.content.decode("utf-8"), "Invalid API token"
         )
 
 
@@ -154,6 +163,16 @@ class APIDownloadBotsCodeViewTest(DownloadBotsCodeBaseTestCase):
             "Return value of _download_bots_code"
         )
 
+    def test_request_with_no_token_receives_401(self):
+        request = self.factory.get("")
+
+        response = views.api_download_bots_code(request)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.content.decode("utf-8"), "API token not provided or empty"
+        )
+
     def test_request_with_invalid_token_receives_401(self):
         request = self.factory.get("")
         request.META["HTTP_AUTHORIZATION"] = "WRONG-TOKEN"
@@ -162,8 +181,7 @@ class APIDownloadBotsCodeViewTest(DownloadBotsCodeBaseTestCase):
 
         self.assertEqual(response.status_code, 401)
         self.assertEqual(
-            response.content.decode("utf-8"),
-            "Invalid API token"
+            response.content.decode("utf-8"), "Invalid API token"
         )
 
     @override_settings(BOTANY_TOURNAMENT_CLOSE_AT=TOMORROW)

--- a/server/botany/tests/test_views.py
+++ b/server/botany/tests/test_views.py
@@ -26,19 +26,20 @@ class APISubmitViewTest(TestCase):
 
     def test_request_with_valid_token_receives_200(self):
         data = {
-            "api_token": "TOKEN",
             "bot_name": "bot.py",
             "bot_code": factories.bot_code("randobot")
         }
 
         request = self.factory.post("", data=data)
+        request.META["HTTP_AUTHORIZATION"] = "TOKEN"
 
         response = views.api_submit(request)
 
         self.assertEqual(response.status_code, 200)
 
     def test_request_with_invalid_token_receives_401(self):
-        request = self.factory.post("", data={"api_token": "WRONG-TOKEN"})
+        request = self.factory.post("")
+        request.META["HTTP_AUTHORIZATION"] = "WRONG-TOKEN"
 
         response = views.api_submit(request)
 

--- a/server/botany/views.py
+++ b/server/botany/views.py
@@ -344,7 +344,7 @@ def api_submit(request):
         return HttpResponseBadRequest("Tournament has closed.")
 
     try:
-        user = User.objects.get(api_token=request.POST["api_token"])
+        user = User.objects.get(api_token=request.META["HTTP_AUTHORIZATION"])
     except User.DoesNotExist:
         return HttpResponseUnauthorized("Invalid API token")
 

--- a/server/botany/views.py
+++ b/server/botany/views.py
@@ -362,9 +362,9 @@ def _download_bots_code():
 
 
 def download_bots_code(request):
-    if datetime.now(timezone.utc) < settings.BOTANY_TOURNAMENT_CLOSE_AT:
+    if get_tournament_state() != TOURNAMENT_STATE.CLOSED:
         raise Http404(
-            "Unable to download bots while tournament is still in progress"
+            "Unable to download bots until tournament is complete"
         )
 
     if not request.user.is_authenticated:
@@ -374,9 +374,9 @@ def download_bots_code(request):
 
 
 def api_download_bots_code(request):
-    if datetime.now(timezone.utc) < settings.BOTANY_TOURNAMENT_CLOSE_AT:
+    if get_tournament_state() != TOURNAMENT_STATE.CLOSED:
         return HttpResponseBadRequest(
-            "Unable to download bots while tournament is still in progress"
+            "Unable to download bots until tournament is complete"
         )
 
     # check that user exists with given token

--- a/server/botany/views.py
+++ b/server/botany/views.py
@@ -343,8 +343,12 @@ def api_submit(request):
     if get_tournament_state() == TOURNAMENT_STATE.CLOSED:
         return HttpResponseBadRequest("Tournament has closed.")
 
+    api_token = request.META.get("HTTP_AUTHORIZATION", "")
+    if api_token == "":
+        return HttpResponseUnauthorized("API token not provided or empty")
+
     try:
-        user = User.objects.get(api_token=request.META["HTTP_AUTHORIZATION"])
+        user = User.objects.get(api_token=api_token)
     except User.DoesNotExist:
         return HttpResponseUnauthorized("Invalid API token")
 
@@ -390,8 +394,12 @@ def api_download_bots_code(request):
         )
 
     # check that user exists with given token
+    api_token = request.META.get("HTTP_AUTHORIZATION", "")
+    if api_token == "":
+        return HttpResponseUnauthorized("API token not provided or empty")
+
     try:
-        User.objects.get(api_token=request.META["HTTP_AUTHORIZATION"])
+        User.objects.get(api_token=api_token)
     except User.DoesNotExist:
         return HttpResponseUnauthorized("Invalid API token")
 


### PR DESCRIPTION
Fix #49

Some notes:

1. This includes two commits from #50
2. 9508dba changes the authentication process for the API submit view to match the download view for consistency (download view uses Authorization header because unlike the submit view it's only accessed via GET requests).

Let me know if there's anything I can improve!